### PR TITLE
CMS diagram

### DIFF
--- a/docs/Platforms/cms.md
+++ b/docs/Platforms/cms.md
@@ -3,7 +3,7 @@ layout: default
 title: "Tallwave Guidelines — Platforms — Content Websites"
 ---
 
-[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/platforms)
+[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/Platforms)
 
 # Content Based Websites
 

--- a/docs/Platforms/cms.md
+++ b/docs/Platforms/cms.md
@@ -71,3 +71,18 @@ Many CMSes support all of these features, but as add-ons. The strength of Drupal
 
 * [Acquia](https://www.acquia.com). Acquia has additional services beyond hosting, such as [Lift](https://www.acquia.com/products-services/acquia-lift), which allows for intelligent customization of content on a per-user basis.
 * [Pantheon](https://pantheon.io)
+
+### Choosing a CMS
+Either WordPress or Drupal can be used to build nearly any website, however each has its own strengths and weaknesses. This chart breaks down which platform is more appropriate for certain requirements:
+
+&nbsp; | WordPress | Drupal
+--------- | --------- | ------
+Content-heavy site | ✅ | |
+Marketing site | ✅ | |
+Landing pages | ✅ | |
+Content workflows | | ✅ |
+Granular security roles and requirements | | ✅ |
+Enterprise integrations | | ✅ |
+Small # of templates | ✅ | |
+Medium # of templates | ✅ | ✅ |
+Large # of templates | | ✅ |

--- a/docs/Platforms/index.md
+++ b/docs/Platforms/index.md
@@ -7,4 +7,4 @@ title: "Tallwave Guidelines — Platforms"
 
 # Platforms
 
-We focus on building software for three platforms: the [web]({% if site.github.is_project_page %}/guidelines{% endif %}/platforms/webapps), [mobile]({% if site.github.is_project_page %}/guidelines{% endif %}/platforms/mobile), and [CMSes]({% if site.github.is_project_page %}/guidelines{% endif %}/platforms/cms).
+We focus on building software for three platforms: the [web]({% if site.github.is_project_page %}/guidelines{% endif %}/Platforms/webapps), [mobile]({% if site.github.is_project_page %}/guidelines{% endif %}/Platforms/mobile), and [CMSes]({% if site.github.is_project_page %}/guidelines{% endif %}/Platforms/cms).

--- a/docs/Platforms/mobile.md
+++ b/docs/Platforms/mobile.md
@@ -3,7 +3,7 @@ layout: default
 title: "Tallwave Guidelines — Platforms — Mobile"
 ---
 
-[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/platforms)
+[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/Platforms)
 
 # Mobile
 

--- a/docs/Platforms/webapps.md
+++ b/docs/Platforms/webapps.md
@@ -3,7 +3,7 @@ layout: default
 title: "Tallwave Guidelines — Platforms — Web Apps"
 ---
 
-[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/platforms)
+[&larr; Home]({{ site.root }}/) &mdash; [Platforms]({{ site.root }}/Platforms)
 
 # The Web
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,9 @@ How we [maintain quality]({{ site.root }}/Quality).
 
 The way we [run projects]({{ site.root }}/Projects).
 
-The [three main platforms]({{ site.root }}/platforms) we build on.
-* [Mobile Applications]({{ site.root }}/platforms/mobile)
-* [Web Applications]({{ site.root }}/platforms/webapps)
-* [Content Management Systems]({{ site.root }}/platforms/cms)
+The [three main platforms]({{ site.root }}/Platforms) we build on.
+* [Mobile Applications]({{ site.root }}/Platforms/mobile)
+* [Web Applications]({{ site.root }}/Platforms/webapps)
+* [Content Management Systems]({{ site.root }}/Platforms/cms)
 
 How the [team works and how you advance]({{ site.root }}/Team).


### PR DESCRIPTION
This adds a diagram to help pick between WP and Drupal. Merge after #44.
