### PR TITLE
Docker setup for issue #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,12 @@ NOTE: If this produces an error, you may need to stop the running docker contain
 
 `docker stop 2bdb`
  
- This will stop that running container.
+This will stop that running container.
+
+Or you can instead use:
+
+`docker-compose stop`
+
+and then whenever you want to run the site again:
+
+`docker-compose start`

--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ Or you can instead use:
 and then whenever you want to run the site again:
 
 `docker-compose start`
+
+## Accessing on a mobile device
+To access the site from your mobile device, find the IP Address of your desktop and use that on mobile, i.e. `192.x.x.x:4000`
+
+To find your desktop's IP, you can:
+- run in your (mac/linux) terminal `ifconfig | grep 'inet'` and pick the ip-looking-address that is _not_ `127.0.0.1` (windows should be `ipconfig` for similar results)
+  - mine looks like this; i used the first IP listed: `inet 192.x.x.x netmask 0xffffff00 broadcast 192.x.x.x`
+- visit [this website](https://www.whatismybrowser.com/detect/what-is-my-local-ip-address)
+- follow the directions for your device (windows/mac) found [here](https://www.howtogeek.com/236838/how-to-find-any-devices-ip-address-mac-address-and-other-network-connection-details/)
+
+_*Note*: googling "what is my IP" returns your router's IP Address, which will not work for this case._

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 services:
   site:
     build: .
-    command: bundle exec jekyll server --config _local.yml
+    command: bundle exec jekyll server --config _local.yml --host '0.0.0.0'
     volumes:
       - ./docs:/srv/jekyll
     ports:
-      - "4000:4000"
+      - 4000:4000


### PR DESCRIPTION
This binds the jekyll server to `0.0.0.0` instead of `localhost`. You can now access from `0.0.0.0:4000` on a desktop, and there is an added bonus that we can access it on mobile as well (notes added to `README`).

@TinaHeiligers please confirm this code fixes the problem for you as well!